### PR TITLE
Custom docker images in connectable builds on resin-toradex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Custom docker images in connectable builds [Andrei]
 * Bump meta-resin to include connectable builds [Andrei]
 * Add support for optional supervisor image [Andrei]
 * Update meta-resin to v1.2 [Andrei]

--- a/layers/meta-resin-toradex/recipes-containers/docker-disk/docker-resin-supervisor-disk.bbappend
+++ b/layers/meta-resin-toradex/recipes-containers/docker-disk/docker-resin-supervisor-disk.bbappend
@@ -1,4 +1,4 @@
 # Apalis imx6 
-TARGET_REPOSITORY_apalis-imx6 = "resin/armv7hf-supervisor"
+SUPERVISOR_REPOSITORY_apalis-imx6 = "resin/armv7hf-supervisor"
 # Colibri imx6 
-TARGET_REPOSITORY_colibri-imx6 = "resin/armv7hf-supervisor"
+SUPERVISOR_REPOSITORY_colibri-imx6 = "resin/armv7hf-supervisor"


### PR DESCRIPTION
Connects to resin-os/meta-resin#133-supervisor-custom-image-tag
@telphan @floion
